### PR TITLE
Update 0.index.md

### DIFF
--- a/streamerbot/3.api/3.csharp/core/0.index.md
+++ b/streamerbot/3.api/3.csharp/core/0.index.md
@@ -51,11 +51,11 @@ Write a new log with level `Verbose`
 
 ## Advanced
 ### `GetSource`
-Get the value of the `__source` variable
+Get the value of the `eventSource` variable
 :csharp-method{name=GetSource}
 
 ### `GetEventType`
-Get the value of the `eventType` variable
+Get the value of the `__source` variable
 :csharp-method{name=GetEventType}
 
 ### `CSharpExecuteMethod`


### PR DESCRIPTION
CPH.GetEventType() and CPH.GetSource() were pointing to the incorrect variable names.